### PR TITLE
Remove note about HTTPS absence

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@ img {
 	</head>
 	<body>
 		<h1>Welcome to patrickhurd.pro!</h1>
-		<p>I'm hosted with GitHub Pages. Until GitHub <a href="https://github.com/isaacs/github/issues/156">allows GitHub Pages with custom domains to use HTTPS</a>, we will have to do without.</p>
+		<p>I'm hosted with GitHub Pages.</p>
 			
 		<hr>
 


### PR DESCRIPTION
From May 01, 2018 GitHub know to HTTPS on custom GH Pages.